### PR TITLE
Implement CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,44 @@ $ gem install mysql_alter_monitoring
 
 ## Usage
 
-TODO
+### Command line
+
+All commands require the specification of host, user name, password.
+
+It can also be specified in URL format using the --url option.
+
+#### Enable monitoring settings for the performance schema
+
+```
+$ mysql-alter-monitoring enable --url mysql2://root:pass@localhost:3306
+
+# When specifying host, user, password, etc. separately
+$ mysql-alter-monitoring enable --host localhost --port 3306 --user root --password pass
+```
+
+#### Disable monitoring settings for the performance schema
+
+```
+$ mysql-alter-monitoring disable --url mysql2://root:pass@localhost:3306
+```
+
+#### Start monitoring until event empty
+
+```
+$ mysql-alter-monitoring run --url mysql2://root:pass@localhost:3306
+```
+
+#### Start monitoring forever
+
+```
+$ mysql-alter-monitoring run-forever --url mysql2://root:pass@localhost:3306
+```
+
+#### Show help
+
+```
+$ mysql-alter-monitoring -h
+```
 
 ## Development
 
@@ -73,6 +110,7 @@ $ bin/rake doc
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/akito-fujisaki/mysql_alter_monitoring.
+
 This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/akito-fujisaki/mysql_alter_monitoring/blob/main/CODE_OF_CONDUCT.md).
 
 ## License

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,8 @@ desc 'Generate and Check code documents'
 task :doc do
   require 'yard'
   YARD::CLI::CommandParser.run
-  `yard`.lines(chomp: true).last.match(/\d+/)[0].to_i == 100 || exit(1)
+  output = `yard`.lines(chomp: true)
+  exit(1) if output.first.include?('[warn]') || output.last.match(/\d+/)[0].to_i != 100
 end
 
 task default: %i[spec lint doc]

--- a/lib/mysql_alter_monitoring.rb
+++ b/lib/mysql_alter_monitoring.rb
@@ -12,6 +12,7 @@ require_relative 'mysql_alter_monitoring/performance_schema_setting'
 require_relative 'mysql_alter_monitoring/json_logger'
 require_relative 'mysql_alter_monitoring/client'
 require_relative 'mysql_alter_monitoring/monitor'
+require_relative 'mysql_alter_monitoring/cli'
 
 # MysqlAlterMonitoring
 module MysqlAlterMonitoring

--- a/lib/mysql_alter_monitoring/cli.rb
+++ b/lib/mysql_alter_monitoring/cli.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+module MysqlAlterMonitoring
+  # MysqlAlterMonitoring::CLI
+  class CLI
+    # @param args [Array<String>]
+    # @param io [::IO]
+    # @return [void]
+    def initialize(args, io: $stdout)
+      @args = args
+      @io = io
+      @options = {}
+    end
+
+    # @return [void]
+    # @raise [MysqlAlterMonitoring::Error]
+    def run # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+      parse!
+
+      return if help? || version?
+
+      client = Client.new(build_config)
+
+      case options[:command]
+      when 'enable'
+        PerformanceSchemaSetting.new(client, io).enable!
+      when 'disable'
+        PerformanceSchemaSetting.new(client, io).disable!
+      when 'run'
+        Monitor.new(client, io).run_until_empty_event
+      when 'run-forever'
+        Monitor.new(client, io).run_forever
+      else
+        raise ArgumentError, "Invalid command: #{options[:command]}"
+      end
+    rescue OptionParser::InvalidOption, ArgumentError => e
+      io.puts e.message
+      io.puts help
+    rescue Interrupt
+      io.puts 'Bye!'
+    end
+
+    # @return [String]
+    def help
+      parser.help
+    end
+
+    private
+
+    # @!attribute [r] args
+    # @return [Array<String>]
+    attr_reader :args
+    # @!attribute [r] options
+    # @return [Hash]
+    attr_reader :options
+    # @!attribute [r] io
+    # @return [::IO]
+    attr_reader :io
+
+    # @return [OptionParser]
+    def parser # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      @parser ||= OptionParser.new do |opts|
+        opts.banner = 'Usage: mysql-alter-monitoring [command] [options]'
+        opts.separator <<~COMMANDS
+          Commands:
+                  enable      Enable monitoring settings for the performance schema
+                  disable     Disable monitoring settings for the performance schema
+                  run         Start monitoring until event empty
+                  run-forever Start monitoring forever
+        COMMANDS
+        opts.separator('Options:')
+        opts.on('--url VALUE', String, 'example: mysql2://root:pass@localhost:3306') { @options[:url] = _1 }
+        opts.on('--host VALUE', String) { @options[:host] = _1 }
+        opts.on('--port VALUE', Integer, "default: #{Config::DEFAULT_PORT}") { @options[:port] = _1 }
+        opts.on('--user VALUE', String) { @options[:user] = _1 }
+        opts.on('--password VALUE', String) { @options[:password] = _1 }
+        opts.on_tail('-h', '--help', 'Show help') { @options[:help] = true }
+        opts.on_tail('--version', 'Show version') { @options[:version] = true }
+      end
+    end
+
+    # @return [Boolean]
+    def help?
+      options.key?(:help).tap { io.puts help if _1 }
+    end
+
+    # @return [Boolean]
+    def version?
+      options.key?(:version).tap { io.puts "MysqlAlterMonitoring #{MysqlAlterMonitoring::VERSION}" if _1 }
+    end
+
+    # @return [MysqlAlterMonitoring::Config]
+    def build_config
+      return Config.build_by_url(options[:url] || '') if options.key?(:url)
+
+      Config.new(
+        host: options[:host] || '',
+        port: options[:port] || 0,
+        user: options[:user] || '',
+        password: options[:password] || ''
+      )
+    end
+
+    # @return [Hash]
+    # @raise OptionParser::InvalidOption
+    def parse!
+      command = parser.parse(args).first || ''
+      @options.merge!(command: command)
+    end
+  end
+end

--- a/lib/mysql_alter_monitoring/config.rb
+++ b/lib/mysql_alter_monitoring/config.rb
@@ -6,6 +6,9 @@ module MysqlAlterMonitoring
     # @return [String]
     SUPPROTED_URI_SCHEME = 'mysql2'
     private_constant :SUPPROTED_URI_SCHEME
+    # @return [Integer]
+    DEFAULT_PORT = 3306
+    public_constant :DEFAULT_PORT
 
     class << self
       # Build config in DATABSE_URL format used in Rails.
@@ -46,11 +49,24 @@ module MysqlAlterMonitoring
     # @param user [String]
     # @param password [String]
     # @return [void]
+    # @raise [ArgumentError]
     def initialize(host:, port:, user:, password:)
       @host = host
-      @port = port || 3306
+      @port = port || DEFAULT_PORT
       @user = user
       @password = password
+      validate!
+    end
+
+    private
+
+    # @return [void]
+    # @raise [ArgumentError]
+    def validate!
+      raise ArgumentError, 'host must be specified' if host.empty?
+      raise ArgumentError, 'port must be positive' unless port.positive?
+      raise ArgumentError, 'user must be specified' if user.empty?
+      raise ArgumentError, 'password must be specified' if password.empty?
     end
   end
 end

--- a/lib/mysql_alter_monitoring/json_logger.rb
+++ b/lib/mysql_alter_monitoring/json_logger.rb
@@ -1,45 +1,47 @@
 # frozen_string_literal: true
 
-# JsonLogger
-class JsonLogger
-  # @return [Proc]
-  FORMATTER = (proc do |severity, timestamp, _progname, msg|
-                 JSON.parse(String(msg), symbolized_name: true)
-                     .merge(level: severity, timestamp: timestamp)
-                     .then { "#{JSON.generate(_1)}\n" }
-               end).freeze
-  private_constant :FORMATTER
+module MysqlAlterMonitoring
+  # MysqlAlterMonitoring::JsonLogger
+  class JsonLogger
+    # @return [Proc]
+    FORMATTER = (proc do |severity, timestamp, _progname, msg|
+                   JSON.parse(String(msg), symbolized_name: true)
+                       .merge(level: severity, timestamp: timestamp)
+                       .then { "#{JSON.generate(_1)}\n" }
+                 end).freeze
+    private_constant :FORMATTER
 
-  # @param io [::IO]
-  # @return [void]
-  def initialize(io)
-    @logger = ::Logger.new(io, formatter: FORMATTER)
-  end
+    # @param io [::IO]
+    # @return [void]
+    def initialize(io)
+      @logger = ::Logger.new(io, formatter: FORMATTER)
+    end
 
-  # @param hash [Hash]
-  # @return [void]
-  def info(hash)
-    build_message(hash).then { logger.info(_1) }
-  end
+    # @param hash [Hash]
+    # @return [void]
+    def info(hash)
+      build_message(hash).then { logger.info(_1) }
+    end
 
-  # @param error [Exception]
-  # @param hash [Hash]
-  # @return [void]
-  def error(error, hash = {})
-    hash.merge(error_class: error.class.name, error_message: error.message)
-        .then { build_message(_1) }
-        .then { logger.error(_1) }
-  end
+    # @param error [Exception]
+    # @param hash [Hash]
+    # @return [void]
+    def error(error, hash = {})
+      hash.merge(error_class: error.class.name, error_message: error.message)
+          .then { build_message(_1) }
+          .then { logger.error(_1) }
+    end
 
-  private
+    private
 
-  # @!attribute [r] logger
-  # @return [Logger]
-  attr_reader :logger
+    # @!attribute [r] logger
+    # @return [Logger]
+    attr_reader :logger
 
-  # @param hash [Hash]
-  # @return [String]
-  def build_message(hash)
-    JSON.generate(hash)
+    # @param hash [Hash]
+    # @return [String]
+    def build_message(hash)
+      JSON.generate(hash)
+    end
   end
 end

--- a/lib/mysql_alter_monitoring/monitor.rb
+++ b/lib/mysql_alter_monitoring/monitor.rb
@@ -15,7 +15,7 @@ module MysqlAlterMonitoring
       @client = client
       @logger = JsonLogger.new(io)
       @logging_interval = logging_interval
-      @performance_schema_setting = PerformanceSchemaSetting.new(client)
+      @performance_schema_setting = PerformanceSchemaSetting.new(client, io)
     end
 
     # Fetch ALTER TABLE events at specified intervals and output in JSON format to specified IO.

--- a/lib/mysql_alter_monitoring/performance_schema_setting.rb
+++ b/lib/mysql_alter_monitoring/performance_schema_setting.rb
@@ -4,24 +4,26 @@ module MysqlAlterMonitoring
   # MysqlAlterMonitoring::PerformanceSchemaSetting
   class PerformanceSchemaSetting
     # @param client [MysqlAlterMonitoring::Client]
+    # @param io [::IO]
     # @return [void]
-    def initialize(client)
+    def initialize(client, io)
       @client = client
+      @logger = JsonLogger.new(io)
     end
 
     # @return [void]
     def enable!
       client.query <<~SQL
-        UPDATE performance_schema.setup_instruments
-        SET ENABLED = 'YES'
+        UPDATE performance_schema.setup_instruments SET ENABLED = 'YES'
         WHERE NAME LIKE 'stage/innodb/alter%'
       SQL
 
       client.query <<~SQL
-        UPDATE performance_schema.setup_consumers
-        SET ENABLED = 'YES'
+        UPDATE performance_schema.setup_consumers SET ENABLED = 'YES'
         WHERE NAME LIKE '%stages%'
       SQL
+
+      logger.info({ message: 'Enable monitoring settings for the performance schema' })
     end
 
     # @return [Boolean]
@@ -41,16 +43,16 @@ module MysqlAlterMonitoring
     # @return [void]
     def disable!
       client.query <<~SQL
-        UPDATE performance_schema.setup_instruments
-        SET ENABLED = 'NO'
+        UPDATE performance_schema.setup_instruments SET ENABLED = 'NO'
         WHERE NAME LIKE 'stage/innodb/alter%'
       SQL
 
       client.query <<~SQL
-        UPDATE performance_schema.setup_consumers
-        SET ENABLED = 'NO'
+        UPDATE performance_schema.setup_consumers SET ENABLED = 'NO'
         WHERE NAME LIKE '%stages%'
       SQL
+
+      logger.info({ message: 'Disable monitoring settings for the performance schema' })
     end
 
     private
@@ -58,5 +60,8 @@ module MysqlAlterMonitoring
     # @!attribute [r] client
     # @return [MysqlAlterMonitoring::Client]
     attr_reader :client
+    # @!attribute [r] logger
+    # @return [JsonLogger]
+    attr_reader :logger
   end
 end

--- a/spec/mysql_alter_monitoring/cli_spec.rb
+++ b/spec/mysql_alter_monitoring/cli_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+RSpec.describe MysqlAlterMonitoring::CLI do
+  let(:cli) { described_class.new(args, io: io) }
+  let(:io) { StringIO.new }
+  let(:logs) { io.tap(&:rewind).readlines.map(&:chomp) }
+
+  context 'when a non-existent option is specified' do
+    let(:args) { ['run', '--foo', 'bar'] }
+    let(:expected_logs) { ['invalid option: --foo'] + cli.help.split("\n") }
+
+    it do
+      cli.run
+      expect(logs).to eq expected_logs
+    end
+  end
+
+  context 'when a non-existent command is specified' do
+    let(:args) { ['foo', '--url', ENV.fetch('DATABASE_URL')] }
+    let(:expected_logs) { ['Invalid command: foo'] + cli.help.split("\n") }
+
+    it do
+      cli.run
+      expect(logs).to eq expected_logs
+    end
+  end
+
+  context 'when --url is invalid' do
+    let(:args) { ['run', '--url', 'invalid'] }
+    let(:expected_logs) { ['URL scheme must be mysql2'] + cli.help.split("\n") }
+
+    it do
+      cli.run
+      expect(logs).to eq expected_logs
+    end
+  end
+
+  context 'when --help is specified' do
+    let(:args) { ['run', '--help'] }
+    let(:expected_logs) { cli.help.split("\n") }
+
+    it do
+      cli.run
+      expect(logs).to eq expected_logs
+    end
+  end
+
+  context 'when --version is specified' do
+    let(:args) { ['run', '--version'] }
+    let(:expected_logs) { ["MysqlAlterMonitoring #{MysqlAlterMonitoring::VERSION}"] }
+
+    it do
+      cli.run
+      expect(logs).to eq expected_logs
+    end
+  end
+
+  context 'when command is enable' do
+    let(:performance_schema_setting) { instance_double(MysqlAlterMonitoring::PerformanceSchemaSetting) }
+    let(:args) { ['enable', '--url', ENV.fetch('DATABASE_URL')] }
+
+    before do
+      allow(performance_schema_setting).to receive(:enable!)
+      allow(MysqlAlterMonitoring::PerformanceSchemaSetting).to receive(:new).and_return(performance_schema_setting)
+    end
+
+    it do
+      cli.run
+      expect(performance_schema_setting).to have_received(:enable!)
+    end
+  end
+
+  context 'when command is disable' do
+    let(:performance_schema_setting) { instance_double(MysqlAlterMonitoring::PerformanceSchemaSetting) }
+    let(:args) { ['disable', '--url', ENV.fetch('DATABASE_URL')] }
+
+    before do
+      allow(performance_schema_setting).to receive(:disable!)
+      allow(MysqlAlterMonitoring::PerformanceSchemaSetting).to receive(:new).and_return(performance_schema_setting)
+    end
+
+    it do
+      cli.run
+      expect(performance_schema_setting).to have_received(:disable!)
+    end
+  end
+
+  context 'when command is run' do
+    let(:monitor) { instance_double(MysqlAlterMonitoring::Monitor) }
+    let(:args) { ['run', '--url', ENV.fetch('DATABASE_URL')] }
+
+    before do
+      allow(monitor).to receive(:run_until_empty_event)
+      allow(MysqlAlterMonitoring::Monitor).to receive(:new).and_return(monitor)
+    end
+
+    it do
+      cli.run
+      expect(monitor).to have_received(:run_until_empty_event)
+    end
+  end
+
+  context 'when command is run-forever' do
+    let(:monitor) { instance_double(MysqlAlterMonitoring::Monitor) }
+    let(:args) { ['run-forever', '--url', ENV.fetch('DATABASE_URL')] }
+
+    before do
+      allow(monitor).to receive(:run_forever)
+      allow(MysqlAlterMonitoring::Monitor).to receive(:new).and_return(monitor)
+    end
+
+    it do
+      cli.run
+      expect(monitor).to have_received(:run_forever)
+    end
+  end
+end

--- a/spec/mysql_alter_monitoring/config_spec.rb
+++ b/spec/mysql_alter_monitoring/config_spec.rb
@@ -44,4 +44,48 @@ RSpec.describe MysqlAlterMonitoring::Config do
       it { expect { build_by_url }.to raise_error ArgumentError }
     end
   end
+
+  describe '#new' do
+    subject(:new) do
+      described_class.new(
+        host: host,
+        port: port,
+        user: user,
+        password: password
+      )
+    end
+
+    let(:host) { '0.0.0.0' }
+    let(:port) { 3_306 }
+    let(:user) { 'root' }
+    let(:password) { 'pass' }
+
+    context 'when args are valid' do
+      it { is_expected.to be_an_instance_of described_class }
+    end
+
+    context 'when host is empty string' do
+      let(:host) { '' }
+
+      it { expect { new }.to raise_error ArgumentError }
+    end
+
+    context 'when port is 0' do
+      let(:port) { 0 }
+
+      it { expect { new }.to raise_error ArgumentError }
+    end
+
+    context 'when user is empty string' do
+      let(:user) { '' }
+
+      it { expect { new }.to raise_error ArgumentError }
+    end
+
+    context 'when password is empty string' do
+      let(:password) { '' }
+
+      it { expect { new }.to raise_error ArgumentError }
+    end
+  end
 end

--- a/spec/mysql_alter_monitoring/monitor_spec.rb
+++ b/spec/mysql_alter_monitoring/monitor_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe MysqlAlterMonitoring::Monitor do
   let(:io) { StringIO.new }
   let(:monitor) { described_class.new(build_client, io, logging_interval: 0.1) }
-  let(:performance_schema_setting) { MysqlAlterMonitoring::PerformanceSchemaSetting.new(build_client) }
+  let(:performance_schema_setting) { MysqlAlterMonitoring::PerformanceSchemaSetting.new(build_client, StringIO.new) }
 
   describe '#run_until_empty_event' do
     subject(:logs) { io.tap(&:rewind).readlines.map { JSON.parse(_1, symbolize_names: true) } }

--- a/spec/mysql_alter_monitoring/performance_schema_setting_spec.rb
+++ b/spec/mysql_alter_monitoring/performance_schema_setting_spec.rb
@@ -1,11 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe MysqlAlterMonitoring::PerformanceSchemaSetting do
-  let(:performance_schema_setting) { described_class.new(build_client) }
+  let(:performance_schema_setting) { described_class.new(build_client, io) }
+  let(:io) { StringIO.new }
+  let(:logs) { io.tap(&:rewind).readlines.map { JSON.parse(_1, symbolize_names: true) } }
+
+  before { freeze_time }
 
   after { performance_schema_setting.enable! }
 
-  it do
+  it 'can be toggled enable and disable' do
     performance_schema_setting.enable!
 
     expect(performance_schema_setting.enable?).to be true
@@ -13,5 +17,11 @@ RSpec.describe MysqlAlterMonitoring::PerformanceSchemaSetting do
     performance_schema_setting.disable!
 
     expect(performance_schema_setting.enable?).to be false
+
+    expected_logs = [
+      { level: 'INFO', message: 'Enable monitoring settings for the performance schema', timestamp: Time.now.to_s },
+      { level: 'INFO', message: 'Disable monitoring settings for the performance schema', timestamp: Time.now.to_s }
+    ]
+    expect(logs).to eq expected_logs
   end
 end


### PR DESCRIPTION
```
Usage: mysql-alter-monitoring [command] [options]
Commands:
        enable      Enable monitoring settings for the performance schema
        disable     Disable monitoring settings for the performance schema
        run         Start monitoring until event empty
        run-forever Start monitoring forever
Options:
        --url VALUE                  example: mysql2://root:pass@localhost:3306
        --host VALUE
        --port VALUE                 default: 3306
        --user VALUE
        --password VALUE
    -h, --help                       Show help
        --version                    Show version
```