### PR TITLE
Set `IO#sync` to true

### DIFF
--- a/lib/mysql_alter_monitoring/cli.rb
+++ b/lib/mysql_alter_monitoring/cli.rb
@@ -8,7 +8,7 @@ module MysqlAlterMonitoring
     # @param args [Array<String>]
     # @param io [::IO]
     # @return [void]
-    def initialize(args, io: $stdout)
+    def initialize(args, io: $stdout.tap { _1.sync = true })
       @args = args
       @io = io
       @options = {}


### PR DESCRIPTION
**Background**

When `IO#sync` is not set to true, standard output may be buffered.

**Solution**

Set `IO#sync` to true